### PR TITLE
require https connections

### DIFF
--- a/pipeline/terraform/env.sh.example
+++ b/pipeline/terraform/env.sh.example
@@ -33,3 +33,6 @@ export TF_VAR_ecs_asg_min_size=2
 
 # autoscaling group maximum number of instances
 export TF_VAR_ecs_asg_max_size=2
+
+# HTTPS certificate ARN from AWS certificate manager
+export TF_VAR_certificate_arn=arn:aws:acm:us-east-1:123412341234:certificate/12341234-3144-4c26-ba3c-123412341234

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -181,8 +181,10 @@ resource "aws_alb" "main" {
 
 resource "aws_alb_listener" "front_end" {
   load_balancer_arn = "${aws_alb.main.id}"
-  port              = "80"
-  protocol          = "HTTP"
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = "${var.certificate_arn}"
 
   default_action {
     target_group_arn = "${aws_alb_target_group.eagle.id}"
@@ -198,15 +200,8 @@ resource "aws_security_group" "lb_sg" {
 
   ingress {
     protocol    = "tcp"
-    from_port   = 80
-    to_port     = 80
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    protocol    = "tcp"
-    from_port   = 50000
-    to_port     = 50000
+    from_port   = 443
+    to_port     = 443
     cidr_blocks = ["0.0.0.0/0"]
   }
 

--- a/pipeline/terraform/variables.tf
+++ b/pipeline/terraform/variables.tf
@@ -8,6 +8,10 @@ variable "create_bastion" {
   default = false
 }
 
+variable "certificate_arn" {
+  description = "HTTPS certificate ARN from the AWS Certificate Manager service"
+}
+
 variable "ecs_instance_type" {
   description = "ec2 instance type used by ecs container hosts"
   default = "t2.large"


### PR DESCRIPTION
- This commit replaces the http listener with https
- There is no http->https redirection configured at the moment
- The certificate ARN is required for an https listener so I've made it a required template parameter