### PR TITLE
make path pattern more forgiving

### DIFF
--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -143,7 +143,7 @@ resource "aws_lb_listener_rule" "jenkins" {
 
   condition {
     field  = "path-pattern"
-    values = ["/jenkins/*"]
+    values = ["/jenkins*"]
   }
 }
 


### PR DESCRIPTION
remove the trailing slash from the pattern match so that /jenkins works and it doesn't have to be /jenkins/ with the trailing slash